### PR TITLE
Schematic

### DIFF
--- a/confapp/lib/hcl/cubit/system_verilog_cubit.dart
+++ b/confapp/lib/hcl/cubit/system_verilog_cubit.dart
@@ -14,26 +14,32 @@ class SystemVerilogCubitState {
   final String systemVerilog;
   final GenerationState generationState;
   final String name;
+  final String moduleName;
 
   const SystemVerilogCubitState(
       {required this.systemVerilog,
       required this.generationState,
-      required this.name});
+      required this.name,
+      required this.moduleName});
   const SystemVerilogCubitState.loading()
       : this(
             systemVerilog: 'Loading...',
             generationState: GenerationState.loading,
-            name: 'loading');
-  const SystemVerilogCubitState.done(String systemVerilog, String name)
+            name: 'loading',
+            moduleName: '');
+  const SystemVerilogCubitState.done(
+      String systemVerilog, String name, String moduleName)
       : this(
             systemVerilog: systemVerilog,
             generationState: GenerationState.done,
-            name: name);
+            name: name,
+            moduleName: moduleName);
   const SystemVerilogCubitState.initial()
       : this(
             systemVerilog: 'Click "Generate RTL"!',
             generationState: GenerationState.initial,
-            name: 'init');
+            name: 'init',
+            moduleName: '');
 }
 
 /// Controls the generated SystemVerilog to display
@@ -50,7 +56,7 @@ class SystemVerilogCubit extends Cubit<SystemVerilogCubitState> {
     emit(const SystemVerilogCubitState.loading());
   }
 
-  void setRTL(String rtl, String name) {
-    emit(SystemVerilogCubitState.done(rtl, name));
+  void setRTL(String rtl, String name, String moduleName) {
+    emit(SystemVerilogCubitState.done(rtl, name, moduleName));
   }
 }

--- a/confapp/lib/hcl/view/screen/content_widget.dart
+++ b/confapp/lib/hcl/view/screen/content_widget.dart
@@ -11,9 +11,11 @@ import 'dart:convert';
 // need this for creating a download link
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html';
+import 'dart:ui_web' as ui_web;
 
 import 'package:confapp/hcl/cubit/component_cubit.dart';
 import 'package:confapp/hcl/cubit/system_verilog_cubit.dart';
+import 'package:confapp/hcl/view/screen/d3Schematic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -53,6 +55,9 @@ class _SVGeneratorState extends State<SVGenerator> {
 
     return res;
   }
+
+  final yosysWorker = new Worker('yosysWorker.js');
+  var schematicHTML = "";
 
   Widget _generateKnobControl(String label, ConfigKnob knob) {
     final Widget selector;
@@ -303,6 +308,25 @@ class _SVGeneratorState extends State<SVGenerator> {
     );
   }
 
+  Widget _generatedSchCard(double screenHeight, double screenWidth) {
+    return Card(
+        child: Container(
+            alignment: Alignment.center,
+            child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: BlocBuilder<SystemVerilogCubit, SystemVerilogCubitState>(
+                    builder: (context, state) {
+                  if (state.generationState == GenerationState.done) {
+                    return Card(
+                        child: HtmlElementView(
+                      viewType: 'schematic-html',
+                    ));
+                  } else {
+                    return Padding(padding: const EdgeInsets.all(16.0));
+                  }
+                }))));
+  }
+
   Widget _genRtlButton(SystemVerilogCubit rtlCubit, Configurator component) {
     return ElevatedButton(
       key: const Key('generateRTL'),
@@ -314,14 +338,36 @@ class _SVGeneratorState extends State<SVGenerator> {
           await Future.delayed(const Duration(milliseconds: 10));
 
           final rtlRes = await _generateRTL(component);
+          final moduleName = await component.createModule().definitionName;
 
-          rtlCubit.setRTL(rtlRes, component.sanitaryName);
+          yosysWorker.postMessage({'module': moduleName, 'verilog': rtlRes});
+
+          await yosysWorker.onMessage.listen((msg) {
+            // TODO(desmonddak):  We see that the number of messages increases
+            // with each click
+            print('got msg' + msg.data);
+
+            schematicHTML = d3Schematic(msg.data);
+            ui_web.platformViewRegistry.registerViewFactory(
+                'schematic-html',
+                (int viewID) => IFrameElement()
+                  ..height = '100%'
+                  ..width = '100%'
+                  ..srcdoc = schematicHTML
+                  ..style.border = 'none');
+          });
+
+          // allow some time for registration to happen
+          rtlCubit.setLoading();
+          await Future.delayed(const Duration(milliseconds: 200));
+
+          rtlCubit.setRTL(rtlRes, component.sanitaryName, moduleName);
         } on Exception catch (e) {
           var message = e.toString();
           if (e is RohdHclException) {
             message = e.message;
           }
-          rtlCubit.setRTL('Error generating:\n\n$message', 'error');
+          rtlCubit.setRTL('Error generating:\n\n$message', 'error', '');
         }
       },
       style: btnStyle,
@@ -392,9 +438,10 @@ class _SVGeneratorState extends State<SVGenerator> {
                         appBar: AppBar(
                           title: const Text('Generated Outputs'),
                           bottom: const TabBar(
-                            isScrollable: true,
+                            isScrollable: false,
                             tabs: [
                               Tab(text: 'Generated RTL'),
+                              Tab(text: 'Generated Schematic'),
                               Tab(text: 'JSON Configuration'),
                             ],
                           ),
@@ -402,6 +449,7 @@ class _SVGeneratorState extends State<SVGenerator> {
                         body: TabBarView(
                           children: [
                             _generatedRtlCard(screenHeight, screenWidth),
+                            _generatedSchCard(screenHeight, screenWidth),
                             _generateJsonCard(screenHeight, screenWidth),
                           ],
                         ),

--- a/confapp/lib/hcl/view/screen/content_widget.dart
+++ b/confapp/lib/hcl/view/screen/content_widget.dart
@@ -434,7 +434,7 @@ class _SVGeneratorState extends State<SVGenerator> {
                         maxHeight: screenHeight * 0.85,
                         maxWidth: screenWidth / 3),
                     child: DefaultTabController(
-                      length: 2,
+                      length: 3,
                       child: Scaffold(
                         appBar: AppBar(
                           title: const Text('Generated Outputs'),

--- a/confapp/lib/hcl/view/screen/content_widget.dart
+++ b/confapp/lib/hcl/view/screen/content_widget.dart
@@ -342,10 +342,11 @@ class _SVGeneratorState extends State<SVGenerator> {
 
           yosysWorker.postMessage({'module': moduleName, 'verilog': rtlRes});
 
-          await yosysWorker.onMessage.listen((msg) {
+          await yosysWorker.onMessage.first.then((msg) {
+            //  await yosysWorker.onMessage.listen((msg) {
             // TODO(desmonddak):  We see that the number of messages increases
             // with each click
-            print('got msg' + msg.data);
+            // print('got msg' + msg.data);
 
             schematicHTML = d3Schematic(msg.data);
             ui_web.platformViewRegistry.registerViewFactory(

--- a/confapp/lib/hcl/view/screen/d3Schematic.dart
+++ b/confapp/lib/hcl/view/screen/d3Schematic.dart
@@ -1,0 +1,94 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// d3Schematic.dart
+// Construction of a d3 schematic HTML from d3 JSON.
+//
+// 2024 July 3
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
+
+final _prefix = r"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>d3-hwschematic</title>
+</head>
+<body>
+  </script>
+  <script type="text/javascript" src="d3-hwschematic-assets/d3/dist/d3.js"></script>
+  <!-- <script type="text/javascript" src="d3-hwschematic-assets/d3/dist/d3.min.js"></script>  -->
+  <script type="text/javascript" src="d3-hwschematic-assets/elkjs/lib/elk.bundled.js"></script>
+  <script type="text/javascript" src="d3-hwschematic-assets/d3-hwschematic.js"></script>
+  <link href="d3-hwschematic-assets/d3-hwschematic.css" rel="stylesheet">
+  <style>
+  	body {
+	   margin: 0;
+    }
+  </style>
+</head>
+<body>
+    <svg id="scheme-placeholder"></svg>
+    <script>
+        // schematic rendering script
+        function viewport() {
+          var e = window,
+            a = 'inner';
+          if (!(innerWidth in window)) {
+            a = 'client';
+            e = document.documentElement || document.body;
+          }
+          return {
+            width: e[a + 'Width'],
+            height: e[a + 'Height']
+          }
+        }
+      var exmpl = `
+""";
+
+final _suffix = r"""
+`;
+        var width = viewport().width,
+            height = viewport().height;
+
+        var svg = d3.select("#scheme-placeholder")
+            .attr("width", width)
+            .attr("height", height);
+
+        var orig = document.body.onresize;
+        document.body.onresize = function(ev) {
+            if (orig)
+        	    orig(ev);
+
+            var w = viewport();
+            svg.attr("width", w.width);
+			svg.attr("height", w.height);
+        }
+
+        var hwSchematic = new d3.HwSchematic(svg);
+        var zoom = d3.zoom();
+        zoom.on("zoom", function applyTransform(ev) {
+        	hwSchematic.root.attr("transform", ev.transform)
+        });
+
+        // disable zoom on doubleclick
+        // because it interferes with component expanding/collapsing
+        svg.call(zoom)
+           .on("dblclick.zoom", null)
+
+      graph = JSON.parse(exmpl);
+      if ("creator" in graph) {
+	  graph = d3.HwSchematic.fromYosys(graph);
+      }
+      if (graph.hwMeta && graph.hwMeta.name) {
+          document.title = graph.hwMeta.name;
+	  hwSchematic.bindData(graph);
+      }
+    </script>
+</body>
+</html>
+""";
+
+String d3Schematic(String json) {
+  return _prefix + json + _suffix;
+}

--- a/confapp/web/yosysWorker.js
+++ b/confapp/web/yosysWorker.js
@@ -1,3 +1,11 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// yosysWorker.js
+// Javascript routine to be used in a worker for loading Yosys WebAsm
+//
+// 2024 July 3
+// Author: Desmond Kirkpatrick <desmond.a.kirkpatrick@intel.com>
 
 function LoadModule() {
     return import('https://cdn.jsdelivr.net/npm/@yowasp/yosys/gen/bundle.js');

--- a/confapp/web/yosysWorker.js
+++ b/confapp/web/yosysWorker.js
@@ -1,0 +1,24 @@
+
+function LoadModule() {
+    return import('https://cdn.jsdelivr.net/npm/@yowasp/yosys/gen/bundle.js');
+}
+
+// Call the function to load the module
+ onmessage = async function(e) {
+    moduleName = e.data.module;
+    verilogStr = e.data.verilog;
+
+    var scriptStr = `
+read_verilog -sv input.v
+hierarchy -top ${moduleName}
+proc; opt
+write_json -compat-int out.json`;
+    module = await LoadModule();
+   filesOut = await module.runYosys(["-Q", "-q", "-T", "-s", "cmd.tcl"], {"input.v": `${verilogStr}`, "cmd.tcl": `${scriptStr}`})
+    var fileContents = filesOut['out.json'];
+    this.postMessage(fileContents);
+ }
+
+ // Can we setup this JS file using the JS commands in dart.
+
+

--- a/lib/src/arithmetic/floating_point.dart
+++ b/lib/src/arithmetic/floating_point.dart
@@ -15,7 +15,6 @@
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
-import 'package:rohd_hcl/src/arithmetic/floating_point_value.dart';
 import 'package:rohd_hcl/src/arithmetic/booth.dart';
 import 'package:rohd_hcl/src/arithmetic/compressor.dart';
 

--- a/lib/src/arithmetic/multiplier.dart
+++ b/lib/src/arithmetic/multiplier.dart
@@ -8,8 +8,6 @@
 // 2023 May 29
 // Author: Yao Jing Quek <yao.jing.quek@intel.com>
 
-import 'dart:io';
-
 import 'package:meta/meta.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
@@ -95,7 +93,7 @@ class CompressionTreeMultiplier extends Multiplier {
   }
 }
 
-/// An implementation of an integer multiplier using compression trees
+/// An implementation of an integer multiply accumulate using compression trees
 class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
   /// The final product of the multiplier module.
   @override
@@ -117,6 +115,9 @@ class CompressionTreeMultiplyAccumulate extends MultiplyAccumulate {
     // So the rowshift is valid.
     // But this requires that we prefix the PP with the addend (not add) to
     // keep the evaluate routine working.
+
+    // TODO(desmonddak): This sign extension method for the additional
+    //  addend may only work with signExtendCompact.
 
     final sign = signed ? c[c.width - 1] : Const(0);
     final l = [for (var i = 0; i < c.width; i++) c[i]];

--- a/test/booth_test.dart
+++ b/test/booth_test.dart
@@ -120,8 +120,6 @@ void main() {
     logicZ.put(Z);
     final pp = PartialProductGenerator(logicX, logicY, encoder);
     // ignore: cascade_invocations
-
-    // stdout.write(pp);
     pp.signExtendCompact();
     stdout.write(pp);
     // Add a row for addend
@@ -132,9 +130,6 @@ void main() {
       ..add(Const(1));
     pp.partialProducts.add(l);
     pp.rowShift.add(0);
-    stdout.write(pp);
-
-    final val = pp.evaluate(signed: true);
 
     stdout.write(
         'Test: $i($X) * $j($Y) + $k($Z)= $product vs ${pp.evaluate(signed: true)}\n');

--- a/test/floating_point_test.dart
+++ b/test/floating_point_test.dart
@@ -284,8 +284,7 @@ void main() {
     // expect(adder.out.floatingPointValue.compareTo(out), 0);
   });
 
-  // if you name two tests the same they get run together
-// RippleCarryAdder: cannot access inputs from outside -- super.a issue
+
   test('basic loop adder test2', () {
     final input = [(4.5, 3.75), (9.0, -3.75), (-9.0, 3.9375), (-3.9375, 9.0)];
 

--- a/test/multiplier_test.dart
+++ b/test/multiplier_test.dart
@@ -9,10 +9,8 @@
 
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_hcl/rohd_hcl.dart';
-import 'package:rohd_hcl/src/arithmetic/compressor.dart';
 import 'package:test/test.dart';
 
 void testUnsignedMultiplier(int n, Multiplier Function(Logic a, Logic b) fn) {

--- a/tool/gh_actions/install_d3_hwschematic.sh
+++ b/tool/gh_actions/install_d3_hwschematic.sh
@@ -22,3 +22,8 @@ cp -r doc/d3-hwschematic/node_modules/d3 doc/api/d3-hwschematic-assets
 cp -r doc/d3-hwschematic/node_modules/elkjs doc/api/d3-hwschematic-assets
 cp doc/d3-hwschematic/dist/d3-hwschematic.{css,js} doc/api/d3-hwschematic-assets
 
+mkdir -p confapp/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/d3 confapp/d3-hwschematic-assets
+cp -r doc/d3-hwschematic/node_modules/elkjs confapp/d3-hwschematic-assets
+cp doc/d3-hwschematic/dist/d3-hwschematic.{css,js} confapp/d3-hwschematic-assets
+


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

This includes a new ability to display schematics in a tab after RTL generation

## Related Issue(s)

None

## Testing

Manually tested several RTL examples with different settings.
One failure:  the floating point adder has a bad escape character: we need to sanitize the generated HTML or JSON.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

One major problem is that the d3-schematic-assets area is duplicated in doc/api and confapp (8MB) by running installation.

The other challenge is that this PR is on top of my FP checkins.  We could separate out the file changes for schematic quite
easily, but either way I didn't have a branch to check into on the upstream.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No, as the configurator is fired up people can see a tab for schematics.