### PR TITLE
Compute cache hit without upstream request.valid

### DIFF
--- a/lib/src/memory/cached_request_response_channel.dart
+++ b/lib/src/memory/cached_request_response_channel.dart
@@ -153,9 +153,9 @@ class CachedRequestResponseChannel extends RequestResponseChannelBase {
     final cacheHit = Logic(name: 'cacheHit');
     final camHit = Logic(name: 'camHit');
 
-    cacheReadPort.en <= upstreamReq.valid;
+    cacheReadPort.en <= Const(1);
     cacheReadPort.addr <= upstreamReq.data.addr;
-    cacheHit <= cacheReadPort.valid;
+    cacheHit <= cacheReadPort.valid & upstreamReq.valid;
 
     camReadPort.en <= downstreamResp.valid;
     camReadPort.addr <= downstreamResp.data.id;


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

We created an artificial dependency between upstream request.ready and request.valid because we can simply compute cacheHit which, if the response FIFO is not full, means we are ready.  Before we were calculating cacheHit with request.valid.

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

Ran existing tests.  Didn't add a new one.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Not needed.
